### PR TITLE
Force requirements versioning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-transforms3d
-pyulog
-control
-scipy
-numpy
-pandas
-matplotlib
+transforms3d>=0.3.1
+pyulog>=0.6.0
+control>=0.7.0
+scipy>=1.1.0
+numpy>=1.14.5
+python-dateutil>=2.5.0
+pandas>=0.23.1
+matplotlib>=2.2.2


### PR DESCRIPTION
This PR adds the minimum version for each of the requirements. It's not exactly the minimum for `px4tools`, as I can't currently tell which is the minimum, but I got as base start the current latest version of the current requirements, except `python-dateutil`.
This is to avoid something as http://ci.px4.io:8080/blue/organizations/jenkins/Firmware/detail/PR-9301/16/pipeline/791#step-1104-log-134 to happen.
@lamping7 @dagar FYI.
@jgoppert can you take a look and if it looks good, merge and make a `0.9.5` release to PyPi? Thanks!