### PR TITLE
Require pandas version < 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'control >= 0.7.0',
         'matplotlib >= 2.2.2',
         'numpy >= 1.13.3',
-        'pandas >= 0.23.1',
+        'pandas >= 0.23.1, < 1.0.0',
         'python-dateutil >= 2.5.0',
         'pyulog >= 0.6.0',
         'scipy >= 1.1.0',


### PR DESCRIPTION
The concat function (for example `px4tools.read_ulog('example.ulog').concat(dt=0.1)`) no longer works with recent pandas version higher than 1.0.