### PR TITLE
Bug Fix: ValueError in PX4MessageDict.concat

### DIFF
--- a/px4tools/ulog.py
+++ b/px4tools/ulog.py
@@ -649,7 +649,13 @@ class PX4MessageDict(dict):
         for topic in topics:
             if verbose:
                 print('merging {:s} as of timestamp'.format(topic))
-            df = d[topic]
+            # Copy original dataframe before modification
+            df = d[topic].copy(deep=True)
+            if df.index.name == 'timestamp':
+                # With pandas version >1.0.0 we can set ignore_index=True,
+                # but for older version compatibility, we choose to temporarily set index.name to None.
+                # Since df is a copy, this operation won't affect original dataframe.
+                df.index.name = None
             df.sort_values(by='timestamp', inplace=True)
             m = pd.merge_asof(m, df, 'timestamp')
         m.index = pd.TimedeltaIndex(m.timestamp * 1e3, unit='ns')


### PR DESCRIPTION
Situation:
The original implementation use `TimedeltaIndex` as the index of DataFrame.
However, the default index name of `TimedeltaIndex` is `"timestamp"`, which is duplicate with the column index. Using an index that exist in both index and column will raise a `ValueError`, as `pandas` cannot infer which axis is the user refer to.
For details please refer to issue #40 

Solution:
In this patch I copy the original DataFrame, set the source index to `None` before calling the `sort_values` and `merge_asof` function. This would resolve the duplication problem without modify the `timestamp` column index.